### PR TITLE
bug fix - leaderboard display

### DIFF
--- a/scripts/leaderboard/LeaderboardList.js
+++ b/scripts/leaderboard/LeaderboardList.js
@@ -7,24 +7,16 @@ const leaderboardTarget =  document.querySelector(".scoreboard--container")
 const eventHub = document.querySelector(".container")
 
 eventHub.addEventListener("playerStateChanged", () => {
-    leaderboardData = []
     listLeaderboard()
 })
 
 eventHub.addEventListener("teamStateChanged", () => {
-    leaderboardData = []
     listLeaderboard()
 })
 
-let leaderboardData = [
-    // {
-    // teamName: "",
-    // playerCount: 0,
-    // teamScore: 0
-    // }
-]
 
 export const listLeaderboard = () => {  
+    let leaderboardData = []
     let teams = []
     let players = []
     let scores = []

--- a/scripts/leaderboard/LeaderboardList.js
+++ b/scripts/leaderboard/LeaderboardList.js
@@ -7,10 +7,12 @@ const leaderboardTarget =  document.querySelector(".scoreboard--container")
 const eventHub = document.querySelector(".container")
 
 eventHub.addEventListener("playerStateChanged", () => {
+    leaderboardData = []
     listLeaderboard()
 })
 
 eventHub.addEventListener("teamStateChanged", () => {
+    leaderboardData = []
     listLeaderboard()
 })
 


### PR DESCRIPTION
1. Verify that when a new **team** is created, the leaderboard renders correctly, rather than double rendering
1. Verify that when a new **player** is created, the leaderboard renders correctly, rather than double rendering