### PR TITLE
Filter out full teams from team select

### DIFF
--- a/scripts/teams/TeamSelect.js
+++ b/scripts/teams/TeamSelect.js
@@ -9,8 +9,11 @@ let teams = []
 const teamSizeLimit = 3
 
 eventHub.addEventListener("teamStateChanged", () => {
-  const allTeams = useTeams()
-  render(allTeams)
+  TeamSelect()
+})
+
+eventHub.addEventListener("playerStateChanged", () => {
+  TeamSelect()
 })
 
 const render = () => {

--- a/scripts/teams/TeamSelect.js
+++ b/scripts/teams/TeamSelect.js
@@ -9,12 +9,37 @@ let teams = []
 const teamSizeLimit = 3
 
 eventHub.addEventListener("teamStateChanged", () => {
-  TeamSelect()
+  prepareData()
+  render()
 })
 
 eventHub.addEventListener("playerStateChanged", () => {
-  TeamSelect()
+  prepareData()
+  render()
 })
+
+export const TeamSelect = () => {
+  getTeams()
+    .then(getPlayers)
+    .then(() => {
+      prepareData()
+      render()
+  })
+}
+
+const prepareData = () => {
+  players = usePlayers()
+  teams = useTeams()
+  teams = teams.filter( team => {
+    let playerCount = 0
+    players.forEach( player => {
+      if( player.teamId === team.id) {
+        playerCount++
+      }
+    })
+    return playerCount < teamSizeLimit
+  })
+}
 
 const render = () => {
   contentTarget.innerHTML = `
@@ -27,27 +52,4 @@ const render = () => {
               .join("")}
         </select>
     `
-}
-
-export const TeamSelect = () => {
-  getTeams()
-    .then(getPlayers)
-    .then(() => {
-      players = usePlayers()
-      teams = useTeams()
-      filterOutFullTeams()
-      render()
-  })
-}
-
-const filterOutFullTeams = () => {
-  teams = teams.filter( team => {
-    let playerCount = 0
-    players.forEach( player => {
-      if( player.teamId === team.id) {
-        playerCount++
-      }
-    })
-    return playerCount < teamSizeLimit
-  })
 }

--- a/scripts/teams/TeamSelect.js
+++ b/scripts/teams/TeamSelect.js
@@ -6,7 +6,7 @@ const eventHub = document.querySelector(".container")
 
 let players = []
 let teams = []
-
+const teamSizeLimit = 3
 
 eventHub.addEventListener("teamStateChanged", () => {
   const allTeams = useTeams()
@@ -45,6 +45,6 @@ const filterOutFullTeams = () => {
         playerCount++
       }
     })
-    return playerCount < 3
+    return playerCount < teamSizeLimit
   })
 }

--- a/scripts/teams/TeamSelect.js
+++ b/scripts/teams/TeamSelect.js
@@ -1,14 +1,19 @@
 import {useTeams, getTeams} from "./TeamProvider.js"
+import {getPlayers, usePlayers} from "../player/PlayerProvider.js";
 
 const contentTarget = document.querySelector(".teamSelectContainer")
 const eventHub = document.querySelector(".container")
+
+let players = []
+let teams = []
+
 
 eventHub.addEventListener("teamStateChanged", () => {
   const allTeams = useTeams()
   render(allTeams)
 })
 
-const render = (teams) => {
+const render = () => {
   contentTarget.innerHTML = `
         <select class="dropdown" id="teamSelect">
             <option value="0">Please select a team</option>
@@ -22,8 +27,24 @@ const render = (teams) => {
 }
 
 export const TeamSelect = () => {
-  getTeams().then(() => {
-    const allTeams = useTeams()
-    render(allTeams)
+  getTeams()
+    .then(getPlayers)
+    .then(() => {
+      players = usePlayers()
+      teams = useTeams()
+      filterOutFullTeams()
+      render()
+  })
+}
+
+const filterOutFullTeams = () => {
+  teams = teams.filter( team => {
+    let playerCount = 0
+    players.forEach( player => {
+      if( player.teamId === team.id) {
+        playerCount++
+      }
+    })
+    return playerCount < 3
   })
 }


### PR DESCRIPTION
1. Verify that full teams no longer render to the team select element.
1. Verify that when teams are filled in-session, the team select no-longer shows them.